### PR TITLE
fix: update transfex flag for tx cli 1.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ detect_changed_source_translations:
 	cd edx-bulk-grades && i18n_tool changed
 
 pull_translations: ## pull translations from Transifex
-	tx pull -a -f --mode reviewed
+	tx pull -a -t -f --mode reviewed
 
 push_translations: ## push source translation files (.po) from Transifex
 	tx push -s


### PR DESCRIPTION
The Transifex cli started requiring the -t or --translations flag in the pull command in order to fetch translations.

https://github.com/transifex/cli/pull/96