### PR TITLE
fix: fix issue with constructing an error message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 
+[1.0.1] - 2022-12-21
+* Fix a bug in building error response messaging.
+
 [1.0.0] - 2022-02-16
 * Dropped Support for Django22, 30 and 31
 * Added Support for Django40

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/views.py
+++ b/bulk_grades/views.py
@@ -99,9 +99,9 @@ class GradeImportExport(GradeOnlyExport):
             data = self.processor.status()
             data['error_messages'] = []
             for error_message in self.processor.error_messages:
+                line_numbers = [str(line_number+1) for line_number in self.processor.error_messages[error_message]]
                 is_plural = 's' if len(line_numbers) > 1 else ''
-                line_numbers = ', '.join(str(line_number+1) for line_number in self.processor.error_messages[error_message])
-                new_message = f'{error_message} (on line{is_plural} {line_numbers})'
+                new_message = f'{error_message} (on line{is_plural} {", ".join(line_numbers)})'
 
                 data['error_messages'].append(new_message)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -122,6 +122,36 @@ class GradeImportExportViewTests(ViewTestsMixin, TestCase):
             }
         )
 
+    def test_post_error(self):
+        # Given bad CSV content
+        csv_content = 'bad'
+        csv_file = SimpleUploadedFile('test_file.csv', csv_content.encode('utf8'), content_type='text/csv')
+
+        # When I post the file
+        self.client.login(username=self.staff.username, password=self.password)
+        response = self.client.post(
+            reverse('bulk_grades', args=[self.course_id]),
+            {'csv': csv_file},
+        )
+
+        # Then I get an error response back
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.json(),
+            {
+                'saved': 0,
+                'error_messages': ['Missing column: user_id (on line 1)'],
+                'can_commit': False,
+                'error_rows': [],
+                'waiting': False,
+                'processed': 0,
+                'saved_error_id': None,
+                'percentage': '0.0%',
+                'total': 0,
+                'result_id': None
+            }
+        )
+
 
 class GradeOperationHistoryViewTests(ViewTestsMixin, TestCase):
 


### PR DESCRIPTION
**Description:** During investigation of a failed bulk grade upload, it was identified that the code to return error messaging actually had a bug, `line_numbers` was being referenced before it was being set. This cleans up that logic and removes that bug.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
