### PR TITLE
fix: rebuild requirements since edx-sphinx-theme wasn't removed

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,20 +4,14 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
 coverage==7.2.3
-    # via codecov
+    # via -r requirements/ci.in
 distlib==0.3.6
     # via virtualenv
 filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
 packaging==23.0
     # via tox
 platformdirs==3.2.0
@@ -26,8 +20,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -39,7 +31,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,7 +32,6 @@ celery==5.2.7
     #   edx-celeryutils
 certifi==2022.12.7
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 cffi==1.15.1
@@ -43,7 +42,6 @@ chardet==5.1.0
     # via diff-cover
 charset-normalizer==3.1.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 click==8.1.3
@@ -83,7 +81,6 @@ coverage[toml]==7.2.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
 ddt==1.6.0
     # via -r requirements/quality.txt
@@ -153,7 +150,6 @@ filelock==3.11.0
     #   virtualenv
 idna==3.4
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 iniconfig==2.0.0
@@ -306,9 +302,7 @@ pyyaml==6.0
     #   edx-i18n-tools
 requests==2.28.2
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   slumber
 simplejson==3.19.1
     # via
@@ -372,7 +366,6 @@ typing-extensions==4.5.0
     #   pylint
 urllib3==1.26.15
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 vine==5.0.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -17,7 +17,9 @@ asgiref==3.6.0
     #   -r requirements/test.txt
     #   django
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 beautifulsoup4==4.12.0
     # via pydata-sphinx-theme
 billiard==3.6.4.0
@@ -124,8 +126,6 @@ edx-django-utils==5.3.0
     #   super-csv
 edx-opaque-keys==2.3.0
     # via -r requirements/test.txt
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
@@ -212,7 +212,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.13.1
+pydata-sphinx-theme==0.13.3
     # via sphinx-book-theme
 pygments==2.14.0
     # via
@@ -296,7 +296,7 @@ sphinx==5.3.0
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.0.0
+sphinx-book-theme==1.0.1
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -336,7 +336,9 @@ tomli==2.0.1
 twine==4.0.2
     # via -r requirements/doc.in
 typing-extensions==4.5.0
-    # via rich
+    # via
+    #   pydata-sphinx-theme
+    #   rich
 urllib3==1.26.15
     # via
     #   -r requirements/test.txt


### PR DESCRIPTION
In the previous PR for sphinx theme remvoal, somehow the compiled requirement
files still included edx-sphinx theme. This reruns the upgrade command to get
the package properly removed.
